### PR TITLE
Fixed issues starting Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "debian/jessie64"
+  config.vm.box = "debian/contrib-jessie64"
   config.vm.provision "shell", path: "provision.sh"
 
   config.vm.network "public_network"

--- a/provision.sh
+++ b/provision.sh
@@ -2,5 +2,5 @@
 
 apt-get install --yes puppet || exit 1
 puppet module install puppetlabs-mysql || exit 1
-puppet module install puppetlabs-rabbitmq || exit 1
+puppet module install puppetlabs-rabbitmq --ignore-dependencies || exit 1
 puppet module install puppetlabs-mongodb || exit 1


### PR DESCRIPTION
When I first ran "vagrant up" I got an error that the file system couldn't be mounted. Some research revealed that debian/jessie64 doesn't contain the virtualbox guest additions which means the file system can't be mounted, debian/contrib-jessie64 does contain these additions.

After this the provisioning would fail because puppet/staging and nanliu/staging both try to write to puppet/staging. I'm actually not sure what the correct fix is for this but ignoring dependencies on RabbitMQ (which avoids nanliu/staging being installed) got me unblocked.
