### PR TITLE
Set the version of puppetlabs-mysql to install

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 apt-get install --yes puppet || exit 1
-puppet module install puppetlabs-mysql || exit 1
+puppet module install --version=3.6.2 --ignore-dependencies puppetlabs-mysql || exit 1
 puppet module install puppetlabs-rabbitmq --ignore-dependencies || exit 1
 puppet module install puppetlabs-mongodb || exit 1


### PR DESCRIPTION
vagrant provisioning kept dying on this error for me ...

```
==> default: Debug: hiera(): Looking up mysql::server::databases in YAML backend
==> default: Debug: hiera(): Looking for data source common
==> default: Debug: hiera(): Cannot find datafile /var/lib/hiera/common.yaml, skipping
==> default: Debug: hiera(): Looking up mysql::server::enabled in YAML backend
==> default: Debug: hiera(): Looking for data source common
==> default: Debug: hiera(): Cannot find datafile /var/lib/hiera/common.yaml, skipping
==> default: Debug: hiera(): Looking up mysql::server::manage_service in YAML backend
==> default: Debug: hiera(): Looking for data source common
==> default: Debug: hiera(): Cannot find datafile /var/lib/hiera/common.yaml, skipping
==> default: Debug: hiera(): Looking up mysql::server::old_root_password in YAML backend
==> default: Debug: hiera(): Looking for data source common
==> default: Debug: hiera(): Cannot find datafile /var/lib/hiera/common.yaml, skipping
==> default: Error: Unknown function mysql::deepmerge at /etc/puppet/modules/mysql/manifests/server.pp:117 on node jessie.vagrantup.com
==> default: Error: Unknown function mysql::deepmerge at /etc/puppet/modules/mysql/manifests/server.pp:117 on node jessie.vagrantup.com
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

I presumed it was some compatibility issue with the new version of the module compared to the version when this repo was initially created. I went upstream to https://github.com/puppetlabs/puppetlabs-mysql/releases?after=3.11.0 and found the last version from 2015 based on the timestamp of the initial commit for provision.sh.

My environment:
macos 10.13.6
Vagrant 2.1.1
virtualbox 5.2.12 r122591